### PR TITLE
Build on all three supported OSes

### DIFF
--- a/.github/workflows/build-with-fake.yml
+++ b/.github/workflows/build-with-fake.yml
@@ -18,8 +18,15 @@ jobs:
         dotnet-version: 2.2.401
     - name: Set up FAKE build tool
       run: dotnet tool install --tool-path .fake fake-cli
-    - name: Build with FAKE
+    - name: Build with FAKE (Linux/OSX)
+      if: runner.os != 'Windows'
       run: .fake/fake build
+      env:
+        # Work around https://github.com/actions/setup-dotnet/issues/29
+        DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/2.2.401/x64
+    - name: Build with FAKE (Windows)
+      if: runner.os == 'Windows'
+      run: .fake\fake build
       env:
         # Work around https://github.com/actions/setup-dotnet/issues/29
         DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/2.2.401/x64

--- a/.github/workflows/build-with-fake.yml
+++ b/.github/workflows/build-with-fake.yml
@@ -7,48 +7,15 @@ jobs:
 
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macOS-latest]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 2.2.401
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-    - name: Dump job context
-      env:
-        JOB_CONTEXT: ${{ toJson(job) }}
-      run: echo "$JOB_CONTEXT"
-    - name: Dump steps context
-      env:
-        STEPS_CONTEXT: ${{ toJson(steps) }}
-      run: echo "$STEPS_CONTEXT"
-    - name: Dump runner context
-      env:
-        RUNNER_CONTEXT: ${{ toJson(runner) }}
-      run: echo "$RUNNER_CONTEXT"
-    - name: Dump strategy context
-      env:
-        STRATEGY_CONTEXT: ${{ toJson(strategy) }}
-      run: echo "$STRATEGY_CONTEXT"
-    - name: Dump matrix context
-      env:
-        MATRIX_CONTEXT: ${{ toJson(matrix) }}
-      run: echo "$MATRIX_CONTEXT"
-    # - name: Show dotnet installation path
-    #   run: echo $DOTNET_ROOT
-    # - name: Investigate dotnet installation
-    #   run: ls -lR $DOTNET_ROOT
     - name: Set up FAKE build tool
       run: dotnet tool install --tool-path .fake fake-cli
     - name: Build with FAKE
       run: .fake/fake build
       env:
         # Work around https://github.com/actions/setup-dotnet/issues/29
-        DOTNET_ROOT: $DOTNET_ROOT/2.2.401/x64
+        DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/2.2.401/x64

--- a/.github/workflows/build-with-fake.yml
+++ b/.github/workflows/build-with-fake.yml
@@ -16,14 +16,14 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 2.2.401
-    - name: Show dotnet installation path
-      run: echo $DOTNET_ROOT
-    - name: Investigate dotnet installation
-      run: ls -lR $DOTNET_ROOT
-    # - name: Set up FAKE build tool
-    #   run: dotnet tool install --tool-path .fake fake-cli
-    # - name: Build with FAKE
-    #   run: .fake/fake build
-    #   env:
-    #     # Work around https://github.com/actions/setup-dotnet/issues/29
-    #     DOTNET_ROOT: /opt/hostedtoolcache/dncs/2.2.401/x64
+    # - name: Show dotnet installation path
+    #   run: echo $DOTNET_ROOT
+    # - name: Investigate dotnet installation
+    #   run: ls -lR $DOTNET_ROOT
+    - name: Set up FAKE build tool
+      run: dotnet tool install --tool-path .fake fake-cli
+    - name: Build with FAKE
+      run: .fake/fake build
+      env:
+        # Work around https://github.com/actions/setup-dotnet/issues/29
+        DOTNET_ROOT: $DOTNET_ROOT/2.2.401/x64

--- a/.github/workflows/build-with-fake.yml
+++ b/.github/workflows/build-with-fake.yml
@@ -20,7 +20,7 @@ jobs:
       run: dotnet tool install --tool-path .fake fake-cli
     - name: Build with FAKE (Linux/OSX)
       if: runner.os != 'Windows'
-      run: ls -lR $DOTNET_ROOT
+      run: .fake/fake build
       env:
         # Work around https://github.com/actions/setup-dotnet/issues/29
         DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/2.2.401/x64

--- a/.github/workflows/build-with-fake.yml
+++ b/.github/workflows/build-with-fake.yml
@@ -12,6 +12,10 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.2.401
     - name: Set up FAKE build tool
       run: dotnet tool install --tool-path .fake fake-cli
     - name: Build with FAKE (Linux/OSX)

--- a/.github/workflows/build-with-fake.yml
+++ b/.github/workflows/build-with-fake.yml
@@ -18,15 +18,8 @@ jobs:
         dotnet-version: 2.2.401
     - name: Set up FAKE build tool
       run: dotnet tool install --tool-path .fake fake-cli
-    - name: Build with FAKE (Linux/OSX)
-      if: runner.os != 'Windows'
+    - name: Build with FAKE
       run: .fake/fake build
-      env:
-        # Work around https://github.com/actions/setup-dotnet/issues/29
-        DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/2.2.401/x64
-    - name: Build with FAKE (Windows)
-      if: runner.os == 'Windows'
-      run: .fake\fake build
       env:
         # Work around https://github.com/actions/setup-dotnet/issues/29
         DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/2.2.401/x64

--- a/.github/workflows/build-with-fake.yml
+++ b/.github/workflows/build-with-fake.yml
@@ -16,7 +16,7 @@ jobs:
       run: dotnet tool install --tool-path .fake fake-cli
     - name: Build with FAKE (Linux/OSX)
       if: runner.os != 'Windows'
-      run: .fake/fake build
+      run: ls -lR $DOTNET_ROOT
       env:
         # Work around https://github.com/actions/setup-dotnet/issues/29
         DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/2.2.401/x64

--- a/.github/workflows/build-with-fake.yml
+++ b/.github/workflows/build-with-fake.yml
@@ -7,7 +7,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        # os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     
     steps:
@@ -16,6 +17,30 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 2.2.401
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - name: Dump job context
+      env:
+        JOB_CONTEXT: ${{ toJson(job) }}
+      run: echo "$JOB_CONTEXT"
+    - name: Dump steps context
+      env:
+        STEPS_CONTEXT: ${{ toJson(steps) }}
+      run: echo "$STEPS_CONTEXT"
+    - name: Dump runner context
+      env:
+        RUNNER_CONTEXT: ${{ toJson(runner) }}
+      run: echo "$RUNNER_CONTEXT"
+    - name: Dump strategy context
+      env:
+        STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+      run: echo "$STRATEGY_CONTEXT"
+    - name: Dump matrix context
+      env:
+        MATRIX_CONTEXT: ${{ toJson(matrix) }}
+      run: echo "$MATRIX_CONTEXT"
     # - name: Show dotnet installation path
     #   run: echo $DOTNET_ROOT
     # - name: Investigate dotnet installation

--- a/.github/workflows/build-with-fake.yml
+++ b/.github/workflows/build-with-fake.yml
@@ -16,10 +16,14 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 2.2.401
-    - name: Set up FAKE build tool
-      run: dotnet tool install --tool-path .fake fake-cli
-    - name: Build with FAKE
-      run: .fake/fake build
-      env:
-        # Work around https://github.com/actions/setup-dotnet/issues/29
-        DOTNET_ROOT: /opt/hostedtoolcache/dncs/2.2.401/x64
+    - name: Show dotnet installation path
+      run: echo $DOTNET_ROOT
+    - name: Investigate dotnet installation
+      run: ls -lR $DOTNET_ROOT
+    # - name: Set up FAKE build tool
+    #   run: dotnet tool install --tool-path .fake fake-cli
+    # - name: Build with FAKE
+    #   run: .fake/fake build
+    #   env:
+    #     # Work around https://github.com/actions/setup-dotnet/issues/29
+    #     DOTNET_ROOT: /opt/hostedtoolcache/dncs/2.2.401/x64

--- a/.github/workflows/build-with-fake.yml
+++ b/.github/workflows/build-with-fake.yml
@@ -14,8 +14,15 @@ jobs:
     - uses: actions/checkout@v1
     - name: Set up FAKE build tool
       run: dotnet tool install --tool-path .fake fake-cli
-    - name: Build with FAKE
+    - name: Build with FAKE (Linux/OSX)
+      if: runner.os != 'Windows'
       run: .fake/fake build
+      env:
+        # Work around https://github.com/actions/setup-dotnet/issues/29
+        DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/2.2.401/x64
+    - name: Build with FAKE (Windows)
+      if: runner.os == 'Windows'
+      run: .fake\fake build
       env:
         # Work around https://github.com/actions/setup-dotnet/issues/29
         DOTNET_ROOT: ${{ runner.tool_cache }}/dncs/2.2.401/x64


### PR DESCRIPTION
This requires changing the way we set the `DOTNET_ROOT` environment variable, because it's hosted in a different place on each OS. The location is always available in the `runner.tool_cache` setting, to which we need to append `dncs/$DOTNET_SDK_VERSION/$ARCH` where `$ARCH` is almost always `x64`, and `$DOTNET_SDK_VERSION` is the version we selected earlier in the workflow.